### PR TITLE
Feat: add UV-K5 V3 7.00.07 and UV-K1 7.02.02 bootloader support

### DIFF
--- a/js/flash-k1.js
+++ b/js/flash-k1.js
@@ -34,12 +34,14 @@ const BLOCKED_BOOTLOADERS = [
 ];
 
 // MINIMUM SAFE version for UV-K1
-const MIN_K1_BOOTLOADER = "7.03.01";
+const MIN_K1_BOOTLOADER = "7.02.02"; // or 7.00.07 to match with UV-K5 V3...
 
 // Known bootloader to model mapping
 const BOOTLOADER_TO_MODEL = {
     "5.00.01": "UV-K5 V2",
     "2.00.06": "UV-K5 V1", 
+    "7.00.07": "UV-K5 V3",
+    "7.02.02": "UV-K1",
     "7.03.01": "UV-K1",
     "7.03.02": "UV-K1",
     "7.03.03": "UV-K1",


### PR DESCRIPTION
Hi Sergio,

I suggest adding these version numbers to your verification procedure: my UV-K1 units run bootloader `7.02.02`, and my UV-K5 V3 units run bootloader `7.00.07`. I therefore suggest adjusting `MIN_K1_BOOTLOADER` accordingly.

Thanks for your work.

Armel, F4HWN